### PR TITLE
Possible fix of a runtime error

### DIFF
--- a/exercises/p2p_blocking/blocking.sh
+++ b/exercises/p2p_blocking/blocking.sh
@@ -23,7 +23,7 @@ echo -e "Execution ... "
 rnd1=$(( RANDOM % 100 ))
 rnd2=$(( RANDOM % 100 ))
 
-mpirun -mca btl sm,tcp,self -output-filename out/out -np 1 ./blocking $rnd1 : -np 1 ./blocking $rnd2
+mpirun -mca btl sm,tcp,self -output-filename out/out -np 2 ./blocking $rnd1 $rnd2
 python check_blocking.py $rnd1 $rnd2
 rm -rf out
 


### PR DESCRIPTION
I'm just learning this topic on [codinggame.com](https://www.codingame.com/playgrounds/349/introduction-to-mpi/blocking-communications---exercise) and it doesn't work because an error gets written to the output file and the python script throws an error when trying to read an integer. I replicated it on my machine and changed some parameters that made it work. I don't know if this is right at all (I'm 99% positive it's not), I'm creating this PR just because I can't find where to create an issue (maybe it was disabled). So please, if you have time to look at it, it would be appreciated.